### PR TITLE
Add reusable Docker build and push workflow

### DIFF
--- a/.github/workflows/build_and_push_v2.yaml
+++ b/.github/workflows/build_and_push_v2.yaml
@@ -1,0 +1,91 @@
+name: Docker Build & Push (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        required: true
+        type: string
+        description: "Name of the Docker image (without registry)"
+
+      registry:
+        required: false
+        type: string
+        default: "docker.io"
+        description: "Registry to push to (docker.io or ghcr.io)"
+
+      push:
+        required: false
+        type: boolean
+        default: true
+        description: "Whether to push the image"
+
+      platforms:
+        required: false
+        type: string
+        default: "linux/amd64,linux/arm64"
+        description: "Target platforms"
+
+      tags:
+        required: false
+        type: string
+        default: ""
+        description: "Additional custom tags (optional)"
+
+    secrets:
+      docker_username:
+        required: false
+      docker_password:
+        required: false
+
+permissions:
+  contents: read
+  packages: write      # Needed for GHCR
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ inputs.registry == 'docker.io' && secrets.docker_username || github.actor }}
+          password: ${{ inputs.registry == 'docker.io' && secrets.docker_password || secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags & labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.registry == 'docker.io' && format('{0}/{1}', secrets.docker_username, inputs.image_name) || format('ghcr.io/{0}/{1}', github.repository_owner, inputs.image_name) }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            ${{ inputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ inputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ inputs.platforms }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false


### PR DESCRIPTION
This workflow builds and pushes a Docker image with customizable inputs for image name, registry, platforms, and tags.